### PR TITLE
Make OverviewContainer work as in Zeplin

### DIFF
--- a/src/app/containers/OverviewContainer.js
+++ b/src/app/containers/OverviewContainer.js
@@ -3,17 +3,15 @@ import { Link } from 'react-router-dom';
 
 import pages from '../pages';
 
-const buildSections = ({ text, route, sections = [] }) => {
+// eslint-disable-next-line react/prop-types
+const buildSections = ({ route, sections = [] }) => {
     return (
         <ul className="unstyled mt0-5">
             {sections
-                .reduce(
-                    (acc, { text, id }) => {
-                        acc.push({ text, id, route: `${route}#${id}` });
-                        return acc;
-                    },
-                    [{ text, route }]
-                )
+                .reduce((acc, { text, id }) => {
+                    acc.push({ text, id, route: `${route}#${id}` });
+                    return acc;
+                }, [])
                 .map(({ text, id, route }) => {
                     return (
                         <li key={id}>


### PR DESCRIPTION
Fixing third item of of 'Overview` page in #34.

> In each of the page sections, there is a link to the page that shouldn't be there. Only links to settings/page#something should be there according to the Zeplin design.

Also, a warning was being thrown in the older version because of some keys being the same