### PR TITLE
Fix #96 - Add Alert in Page if require admin permission

### DIFF
--- a/src/app/components/Page.js
+++ b/src/app/components/Page.js
@@ -4,13 +4,27 @@ import { Alert, ObserverSections, SubSidebar, usePermissions } from 'react-compo
 import { hasPermission } from 'proton-shared/lib/helpers/permissions';
 import { c } from 'ttag';
 import { Link } from 'react-router-dom';
+import { PERMISSIONS } from 'proton-shared/lib/constants';
 
 import Main from './Main';
 import Title from './Title';
 
+const { ADMIN, MEMBER } = PERMISSIONS;
+
 const Page = ({ config, children }) => {
     const userPermissions = usePermissions();
     const { sections = [], permissions: pagePermissions, text } = config;
+
+    if (userPermissions.includes(MEMBER) && pagePermissions.includes(ADMIN)) {
+        return (
+            <Main>
+                <Title>{text}</Title>
+                <div className="container-section-sticky">
+                    <Alert type="warning">{c('Warning').t`Require admin permission to access to this page.`}</Alert>
+                </div>
+            </Main>
+        );
+    }
 
     if (!hasPermission(userPermissions, pagePermissions)) {
         return (


### PR DESCRIPTION
![Capture d’écran 2019-08-14 à 06 24 12](https://user-images.githubusercontent.com/1345786/62994468-58f17a80-be5c-11e9-9215-64fd04f8ea1c.png)

We proposed also to [add an illustration](https://gitlab.protontech.ch/design/requests/issues/8).